### PR TITLE
Pin arbor<0.12 to fix broken Arbor API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,13 @@ keywords = [
 ]
 
 [project.optional-dependencies]
-all = ["scoop>=0.7", "pyneuroml>=0.5.20", "libNeuroML>=0.3.1", "LFPy>=2.3", "arbor>=0.10"]
-tests = ["pyneuroml>=0.5.20", "libNeuroML>=0.3.1", "LFPy>=2.3", "arbor>=0.10"]
+all = ["scoop>=0.7", "pyneuroml>=0.5.20", "libNeuroML>=0.3.1", "LFPy>=2.3", "arbor>=0.10,<0.12"]
+tests = ["pyneuroml>=0.5.20", "libNeuroML>=0.3.1", "LFPy>=2.3", "arbor>=0.10,<0.12"]
 tests-no-arbor = ["pyneuroml>=0.5.20", "libNeuroML>=0.3.1", "LFPy>=2.3"]
 scoop = ["scoop>=0.7"]
 neuroml = ["pyneuroml>=0.5.20", "libNeuroML>=0.3.1"]
 lfpy = ["LFPy>=2.3"]
-arbor = ["arbor>=0.10"]
+arbor = ["arbor>=0.10,<0.12"]
 
 [project.urls]
 Homepage = "https://github.com/openbraininstitute/BluePyOpt"


### PR DESCRIPTION
Arbor 0.12.0 (released to PyPI today) removed arbor.iclamp from its Python API. BluePyOpt uses this in protocols.py, causing CI test failures CI:

- test_l5pc_validate_neuron_arbor: AttributeError: module 'arbor' has no attribute 'iclamp'
- test_simplecell_arbor: same
- test_lfpy_evaluator:  cascading None from failed Arbor simulation

This pins arbor>=0.10,<0.12 in all three optional-dependency groups (all, tests, arbor) until BluePyOpt is updated to the new Arbor 0.12 API.